### PR TITLE
Make sure VCR dependency is at least 3.0.3

### DIFF
--- a/twitter_list.gemspec
+++ b/twitter_list.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'pry', '~> 0.10'
   s.add_development_dependency 'webmock'
-  s.add_development_dependency 'vcr'
+  s.add_development_dependency 'vcr', '~> 3.0.3'
 end


### PR DESCRIPTION
Versions of VCR before this version didn't support webmock 2, so we want to make sure that developers always install a compatible version of VCR.

Part of https://github.com/everypolitician/everypolitician/issues/583