### PR TITLE
Retry Twitter list requests 10 times

### DIFF
--- a/lib/twitter_list/scraper.rb
+++ b/lib/twitter_list/scraper.rb
@@ -13,6 +13,8 @@ module TwitterList
         config.consumer_secret     = tokens[:consumer_secret]     || consumer_secret
         config.access_token        = tokens[:access_token]        || access_token
         config.access_token_secret = tokens[:access_token_secret] || access_secret
+        # See: https://github.com/lostisland/faraday/blob/e74f24d852ac467139ca7485744d46c1ee5060c8/lib/faraday/request/retry.rb
+        config.middleware.insert_before Twitter::REST::Response::RaiseError, Faraday::Request::Retry, max: 10, exceptions: [Twitter::Error::NotFound]
       end
     end
 

--- a/spec/twitter_list/scraper_spec.rb
+++ b/spec/twitter_list/scraper_spec.rb
@@ -70,4 +70,29 @@ describe TwitterList::Scraper do
     end
   end
 
+  describe "when a Twitter list temporarily 404s" do
+    let(:tokens) {'abc|123|def|456'}
+    let(:people) {TwitterList::Scraper.new(twitter_tokens: tokens).people('lechinoise', 'politic-arg')}
+    let(:list_url) do
+      'https://api.twitter.com/1.1/lists/members.json?cursor=-1&owner_screen_name=lechinoise&slug=politic-arg'
+    end
+
+    before do
+      # Return 404 error 9 times, then 200.
+      stub_request(:get, list_url).to_return do |request|
+        @count ||= 0
+        @count += 1
+        if @count < 10
+          { status: 404, body: '{"errors":[{"code":34,"message":"Sorry, that page does not exist."}]}' }
+        else
+          { status: 200, body: '{"users": [],"next_cursor":0,"next_cursor_str":"0"}' }
+        end
+      end
+    end
+
+    it 'retries 10 times' do
+      expect(people.size).to eq(0)
+      expect(@count).to eq(10)
+    end
+  end
 end


### PR DESCRIPTION
To try and deal with Twitter sometimes returning a 404 error for list
pages this adds the Faraday "retry" middleware to the Twitter middleware
stack. This is configured to check for a Twitter::Error::NotFound error
and retry the request up to 10 times.

Part of https://github.com/everypolitician/everypolitician/issues/610